### PR TITLE
PR: img 태그의 기본 속성(width, height) 덮어쓰기 이슈 수정

### DIFF
--- a/src/components/image_box.jsx
+++ b/src/components/image_box.jsx
@@ -1,9 +1,7 @@
 import { css, styled } from 'styled-components'
 
-const ImageBox = ({ shape = 'default', width, height, ...rest }) => {
-	return (
-		<S.Img_ImgBox $shape={shape} $width={width} $height={height} {...rest} />
-	)
+const ImageBox = ({ shape = 'default', ...rest }) => {
+	return <S.Img_ImgBox $shape={shape} {...rest} />
 }
 
 export default ImageBox
@@ -19,8 +17,6 @@ const shapeCss = {
 
 const Img_ImgBox = styled.img`
 	${({ $shape }) => shapeCss[$shape]}
-	width: ${($width) => $width};
-	height: ${($height) => $height};
 `
 
 const S = {


### PR DESCRIPTION
## 작업 결과물 
- _Image or Video_
- _component 등 출력물 한정_

[클릭 시, `img` 태그의 기본속성 `width`,`height` 관련 정보를 담은 사이트로 이동합니다.](https://www.tcpschool.com/html-tag-attrs/img-width)

### _변경 전_

<img width="597" alt="스크린샷 2023-11-29 오전 12 55 35" src="https://github.com/2023-frontend1/Paprika-Market-2.0.1/assets/50646145/cb8ca2fd-aaf5-44e0-9379-4260c0d7c1c5">

<br/>

<img width="304" alt="스크린샷 2023-11-29 오전 12 55 49" src="https://github.com/2023-frontend1/Paprika-Market-2.0.1/assets/50646145/be1e6480-2728-4344-8502-b79129615ff6">


### _변경 후_

<img width="440" alt="스크린샷 2023-11-29 오전 12 57 09" src="https://github.com/2023-frontend1/Paprika-Market-2.0.1/assets/50646145/86cfd59a-201f-4fca-a0fb-a05d8c62c126">

<br/>

<img width="319" alt="스크린샷 2023-11-29 오전 12 57 16" src="https://github.com/2023-frontend1/Paprika-Market-2.0.1/assets/50646145/512f522a-f47a-474c-97fc-2ea0c9ebc420">


<br/> 
<br/>

## 작업 상세 내용
- <img/> 기본 속성 중 height, width 가 있음에도, 새로 props 로 전달 받아 스타일 컴포넌트까지 전달했었습니다. 
- 그렇게 전달된 값은 실제 이미지 크기에 반영되지 않는 이슈가 있었습니다.
- 불필요한 props 전달 제거하였습니다.

<br/>
<br/>

## 체크 리스트
- [x] main 브랜치 pull 받기
- [x] reviewer 설정 확인
- [x] Assignees 설정 확인




<br/>

--------------------
🔴 **(Optional) 이건 반드시 확인해 주세요!**

<!-- 여기에다 내용을 작성해주세요. -->


<br/>

--------------------
🟡 **리뷰 작성시, 다음의 형식을 작성바랍니다.!**

- _코드 수정을 요청할 때만, 아래 형식을 맞춰주세요!!_

```text
# Comment Level
  - [ ] N : "변경을 꼭 소원합니다. 🔥" 
  - [ ] M : "좋지만, 난 좀 그래요..🥹"
  - [ ] S : "그냥 멘트입니다. 👍"

# Description

```
